### PR TITLE
Attempt to standardize automation format

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -19,8 +19,8 @@
     - service: light.turn_on
       data:
         entity_id: light.front_porch_lights
-        profile: read
-        brightness_pct: 50
+        profile: relax
+        brightness_pct: 25
         transition: 900
 ################################################################################
 

--- a/automations.yaml
+++ b/automations.yaml
@@ -79,8 +79,8 @@
     - service: light.turn_on
       data:
         entity_id: light.front_porch_lights
-        profile: read
-        brightness_pct: 50
+        profile: relax
+        brightness_pct: 25
         transition: 5
 ################################################################################
 

--- a/automations.yaml
+++ b/automations.yaml
@@ -1,6 +1,6 @@
 ################################################################################
-- id: front_porch_lights_nighttime
-  alias: 'Front Porch - Nighttime Lighting'
+# id: front_porch_lights_nighttime
+- alias: 'Front Porch - Nighttime Lighting'
   trigger:
     - platform: state
       entity_id: sun.sun
@@ -25,8 +25,8 @@
 ################################################################################
 
 ################################################################################
-- id: front_porch_lights_daytime
-  alias: 'Front Porch - Daytime Lighting'
+# id: front_porch_lights_daytime
+- alias: 'Front Porch - Daytime Lighting'
   trigger:
     - platform: state
       entity_id: sun.sun
@@ -40,8 +40,8 @@
 ################################################################################
 
 ################################################################################
-- id: front_door_nighttime_motion_initial
-  alias: 'Front Porch - Nighttime Motion'
+# id: front_door_nighttime_motion_initial
+- alias: 'Front Porch - Nighttime Motion'
   trigger:
     - platform: state
       entity_id: binary_sensor.ring_front_door_motion
@@ -61,8 +61,8 @@
 ################################################################################
 
 ################################################################################
-- id: front_door_nighttime_motion_idle
-  alias: 'Front Porch - Nighttime Motion Idle'
+#id: front_door_nighttime_motion_idle
+- alias: 'Front Porch - Nighttime Motion Idle'
   trigger:
     - platform: state
       entity_id: binary_sensor.ring_front_door_motion
@@ -85,8 +85,8 @@
 ################################################################################
 
 ################################################################################
-- id: location_home
-  alias: "Location - Home"
+# id: location_home
+- alias: "Location - Home"
   trigger:
     - platform: state
       entity_id: 
@@ -120,8 +120,8 @@
 ################################################################################
 
 ################################################################################
-- id: location_away
-  alias: "Location - Away"
+# id: location_away
+- alias: "Location - Away"
   trigger:
     - platform: state
       entity_id: 
@@ -155,16 +155,16 @@
 ################################################################################
 
 ################################################################################
-#- id: nighttime_mode
-#  alias: "Nighttime Mode"
+# id: nighttime_mode
+#- alias: "Nighttime Mode"
 #  trigger:
 #    - platform: time
 #      at: '21:00:00'
 ################################################################################
 
 ################################################################################
-#- id: living_room_motion
-#  alias: 'Living Room Motion'
+# id: living_room_motion
+#- alias: 'Living Room Motion'
 #  trigger:
 #    - platform: state
 #      entity_id: binary_sensor.living_room_motion

--- a/packages/function_alarmclock.yaml
+++ b/packages/function_alarmclock.yaml
@@ -105,8 +105,8 @@ automation:
 
 script:
 ################################################################################
-#  wakeup_apple_tv:
-  - alias: 'Wakeup - Apple TV'
+  wakeup_apple_tv:
+    alias: 'Wakeup - Apple TV'
     sequence:
   # Turn on the TV
       - service: media_player.turn_on

--- a/packages/function_alarmclock.yaml
+++ b/packages/function_alarmclock.yaml
@@ -42,8 +42,8 @@ input_boolean:
 
 automation:
 ################################################################################
-  - id: wakeup_apple_tv
-    alias: 'Wakeup - Apple TV'
+# id: wakeup_apple_tv
+  - alias: 'Wakeup - Apple TV'
     trigger:
     - platform: template
       value_template: >
@@ -70,8 +70,8 @@ automation:
 ################################################################################
   
 ################################################################################
-  - id: wakeup_light_bedroom
-    alias: 'Wakeup - Bedroom Light'
+# id: wakeup_light_bedroom
+  - alias: 'Wakeup - Bedroom Light'
     trigger:
     - platform: template
       value_template: >
@@ -105,8 +105,8 @@ automation:
 
 script:
 ################################################################################
-  wakeup_apple_tv:
-    alias: 'Wakeup - Apple TV'
+#  wakeup_apple_tv:
+  - alias: 'Wakeup - Apple TV'
     sequence:
   # Turn on the TV
       - service: media_player.turn_on

--- a/packages/platform_roomba.yaml
+++ b/packages/platform_roomba.yaml
@@ -9,7 +9,7 @@ homeassistant:
 # Upstairs Roomba
     switch.roomba_upstairs:
       friendly_name: "Upstairs Roomba"
-      icon: mdi:roomba
+      icon: mdi:robot-vacuum
     sensor.roomba_upstairs_battery:
       friendly_name: "Upstairs Roomba Battery"
     sensor.roomba_upstairs_status:
@@ -18,7 +18,7 @@ homeassistant:
 # Downstairs Roomba
     switch.roomba_downstairs:
       friendly_name: "Downstairs Roomba"
-      icon: mdi:roomba
+      icon: mdi:robot-vacuum
     sensor.roomba_downstairs_battery:
       friendly_name: "Downstairs Roomba Battery"
     sensor.roomba_downstairs_status:


### PR DESCRIPTION
`id:` field is used for the automation editor, which I never use.