### PR TITLE
Removed `icon` value from UniFi component.

### DIFF
--- a/packages/platform_unifi.yaml
+++ b/packages/platform_unifi.yaml
@@ -21,7 +21,6 @@ device_tracker:
     new_device_defaults:
       track_new_devices: true
       hide_if_away: false
-    icon: mdi:network
 
 # Really need some sort of a value_template here to set statuses
 # to 'online' and 'offline'.


### PR DESCRIPTION
It still overrides `known_devices.yaml`.